### PR TITLE
Add lvk subdomain redirect configuration

### DIFF
--- a/subdomains/lvk.yaml
+++ b/subdomains/lvk.yaml
@@ -1,0 +1,5 @@
+lvk:
+  redirect_from: ["lvk.ayy.fi", "www.lvk.ayy.fi"]
+  redirect_to: "https://lampovoimakerho.fi"
+  include_path: true
+  permanent: true


### PR DESCRIPTION
This pull request adds the configuration for redirecting the lvk subdomain to the https://lampovoimakerho.fi website. The redirect is permanent and includes the path.